### PR TITLE
fix(auth): Update session cookie SameSite policy for OAuth compatibility

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -199,7 +199,7 @@ export async function googleAuthHandler(req: Request, res: Response): Promise<Re
     res.cookie('session_id', sessionId, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      sameSite: process.env.NODE_ENV === 'production' ? 'lax' : 'lax',
       maxAge: expiresIn * 1000, // Convert to milliseconds
       path: '/'
     });

--- a/src/middleware/csrf.middleware.ts
+++ b/src/middleware/csrf.middleware.ts
@@ -60,7 +60,7 @@ export async function csrfTokenGenerator(req: Request, res: Response, next: Next
     res.cookie(CSRF_COOKIE_NAME, token, {
       httpOnly: false,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      sameSite: process.env.NODE_ENV === 'production' ? 'lax' : 'lax',
       maxAge: CSRF_TOKEN_EXPIRY * 1000
     });
   }


### PR DESCRIPTION
- Change session cookie SameSite from 'strict' to 'lax' in auth.controller.ts
- Update CSRF middleware cookie policy to use 'lax' for OAuth popup support
- Maintains security while enabling Google OAuth popup communication

Part of: Phase 1 OAuth authentication critical fixes